### PR TITLE
Ff fixes

### DIFF
--- a/CRM/Anonymiser/Worker.php
+++ b/CRM/Anonymiser/Worker.php
@@ -110,6 +110,11 @@ class CRM_Anonymiser_Worker {
           $this->log(ts("Removed entries for %1 %2(s) from logging table '%3'.", array(1 => count($entity_ids), 2 => $entity_name, 3 => $log_table_name, 'domain' => 'de.systopia.anonymiser')));
         } 
       }
+
+      foreach ($this->config->getAffectedLogTables() as $affected_log_table) {
+        $entity_name = $this->config->getEntityForTable($affected_log_table);
+        $this->deleteRelatedLogs($entity_name, $contact_id);
+      }
     }
   }
 
@@ -134,6 +139,28 @@ class CRM_Anonymiser_Worker {
     civicrm_api3('Contact', 'create', $erase_query);
 
     // TODO: anything else?
+  }
+
+  /**
+   * Delete any other log entries related to the contact, even where we did not delete the entity itself
+   * (possibly because it had already been deleted, or is no longer related)
+   * @param $entity_name string the name of the entity as used by the API
+   * @param $contact_id  int    ID of the contact
+   */
+  protected function deleteRelatedLogs($entity_name, $contact_id) {
+    $table_name     = $this->config->getTableForEntity($entity_name);
+    $log_table_name = $this->config->getLogTableForTable($table_name);
+
+    $identifiers = $this->config->getIdentifiers($entity_name, $contact_id);
+    if ($identifiers['join']) return; // Only entities that refer directly to the contact
+    foreach ($identifiers['sql'] as $where_clause) {
+      $query = "DELETE FROM `$log_table_name` WHERE $where_clause";
+      $result = CRM_Core_DAO::executeQuery($query);
+      $row_count = $result->affectedRows();
+      if ($row_count) {
+        $this->log(ts("Removed %1 additional log entries referencing this contact from logging table '%2'.", array(1 => $row_count, 2 => $log_table_name, 'domain' => 'de.systopia.anonymiser')));
+      }
+    }
   }
 
   /**

--- a/CRM/Anonymiser/Worker.php
+++ b/CRM/Anonymiser/Worker.php
@@ -198,7 +198,7 @@ class CRM_Anonymiser_Worker {
                                 FROM civicrm_activity
                                 LEFT JOIN civicrm_activity_contact ON civicrm_activity.id = civicrm_activity_contact.activity_id
                                 WHERE contact_id = $contact_id
-                                  AND 2 <= (SELECT COUNT(DISTINCT(contact_id)) FROM civicrm_activity_contact WHERE civicrm_activity.id = activity_id );";
+                                  AND 2 >= (SELECT COUNT(DISTINCT(contact_id)) FROM civicrm_activity_contact WHERE civicrm_activity.id = activity_id );";
     $identify_activities = CRM_Core_DAO::executeQuery($identify_activities_sql);
     while ($identify_activities->fetch()) {
       $activity_id = $identify_activities->activity_identifier;


### PR DESCRIPTION
I've made 2 changes here:
- Switch the comparison on the count of contacts on an activity, so it deletes only activities with 2 or _less_ contacts including the one we're anonymising.
- Added a function, if we're purging log tables, to also purge _all_ entries that refer to the contact we're anonymising. As previously, if they had 2 Emails, but one was deleted and _then_ the contact was anonymised, log traces would remain of the deleted Email.
  - Further traces may remain, however, if the contact has been deduped. There would be entries relating to the version of the contact at the "losing" ID.