### PR TITLE
fix error if component is disabled

### DIFF
--- a/CRM/Anonymiser/Worker.php
+++ b/CRM/Anonymiser/Worker.php
@@ -69,18 +69,33 @@ class CRM_Anonymiser_Worker {
     $this->deleteActivities($entity_name, $contact_id, $clearedEntities);
 
     // ANONYMISE memberships
-    if ($this->isComponentEnabled('CiviMember') && !$this->config->deleteMemberships()) {
-      $this->anonymiseMemberships($contact_id, $clearedEntities);
+    if (!$this->config->deleteMemberships()){
+      if ($this->isComponentEnabled('CiviMember')){
+        $this->anonymiseMemberships($contact_id, $clearedEntities);
+      }else{
+        $this->log(ts("Warning: Can not anonymize potentiall Membership entries because Component is disabled."));
+      }
     }
+
 
     // ANONYMISE participants
-    if ($this->isComponentEnabled('CiviEvent') && !$this->config->deleteParticipations()) {
-      $this->anonymiseParticipants($contact_id, $clearedEntities);
+    if (!$this->config->deleteParticipations()) {
+      if ($this->isComponentEnabled('CiviEvent')){
+        $this->anonymiseParticipants($contact_id, $clearedEntities);
+      }else{
+        $this->log(ts("Warning: Can not anonymize potentiall Participant entries because Component is disabled."));
+      }
     }
 
+
+
     // ANONYMISE contributions
-    if ($this->isComponentEnabled('CiviContribute') && !$this->config->deleteContributions()) {
-      $this->anonymiseContributions($contact_id, $clearedEntities);
+    if (!$this->config->deleteContributions()) {
+      if ($this->isComponentEnabled('CiviContribute')) {
+        $this->anonymiseContributions($contact_id, $clearedEntities);
+      }else{
+        $this->log(ts("Warning: Can not anonymize potentiall Contribution entries because Component is disabled."));
+      }
     }
 
     // THEN: clean out the basic data

--- a/CRM/Anonymiser/Worker.php
+++ b/CRM/Anonymiser/Worker.php
@@ -65,17 +65,17 @@ class CRM_Anonymiser_Worker {
     $this->deleteActivities($entity_name, $contact_id, $clearedEntities);
 
     // ANONYMISE memberships
-    if (!$this->config->deleteMemberships()) {
+    if ($this->isComponentEnabled('CiviMember') && !$this->config->deleteMemberships()) {
       $this->anonymiseMemberships($contact_id, $clearedEntities);
     }
 
     // ANONYMISE participants
-    if (!$this->config->deleteParticipations()) {
+    if ($this->isComponentEnabled('CiviEvent') && !$this->config->deleteParticipations()) {
       $this->anonymiseParticipants($contact_id, $clearedEntities);
     }
 
     // ANONYMISE contributions
-    if (!$this->config->deleteContributions()) {
+    if ($this->isComponentEnabled('CiviContribute') && !$this->config->deleteContributions()) {
       $this->anonymiseContributions($contact_id, $clearedEntities);
     }
 
@@ -436,5 +436,14 @@ class CRM_Anonymiser_Worker {
    */
   public function getLog() {
     return $this->log;
+  }
+
+    /**
+     * check if this Civi Component is enabled
+     * @param $component
+     * @return bool
+     */
+  private function isComponentEnabled($component) {
+      return in_array($component, Civi::settings()->get('enable_components'), TRUE);
   }
 }

--- a/CRM/Anonymiser/Worker.php
+++ b/CRM/Anonymiser/Worker.php
@@ -58,7 +58,11 @@ class CRM_Anonymiser_Worker {
     // delete entities, that cannot be (sensibly) anonymised
     $entities_to_delete = $this->config->getEntitiesToDelete();
     foreach ($entities_to_delete as $entity_name) {
-      $this->deleteRelatedEntities($entity_name, $contact_id, $clearedEntities);
+      if ($this->isEntityComponentEnabled($entity_name)) {
+          $this->deleteRelatedEntities($entity_name, $contact_id, $clearedEntities);
+      }else{
+          $this->log(ts("Warning: Can not delete potentiall %1 entries because Component is disabled.",array(1 => $entity_name, 'domain' => 'de.systopia.anonymiser')));
+      }
     }
 
     // delete ACTIVITIES
@@ -436,6 +440,28 @@ class CRM_Anonymiser_Worker {
    */
   public function getLog() {
     return $this->log;
+  }
+
+    /**
+     * check if the component for this entity is enabled
+     * currently only checks Membership, Participant, Contribution, ContributionRcur
+     * returns true if component is enabled or not checked
+     * @param $entity
+     * @return bool
+     */
+  private function isEntityComponentEnabled($entity){
+    if ($entity == 'Membership'):
+        return $this->isComponentEnabled('CiviMember');
+    elseif ($entity == 'Participant'):
+        return $this->isComponentEnabled('CiviEvent');
+    elseif ($entity == 'Contribution'):
+        return $this->isComponentEnabled('CiviContribute');
+    elseif ($entity == 'ContributionRecur'):
+        return $this->isComponentEnabled('CiviContribute');
+    else:
+        // assume this component is enabled if it is not explicitly checked
+        return true;
+    endif;
   }
 
     /**


### PR DESCRIPTION
The Extension did throw an error message while trying to anonymize contacts if a component was disabled.
So I added checks if a component is enabled.
If it is disabled an warning is written to the user-output because in this case we can not be sure, that there is no entry for this component and contact.