### PR TITLE
Replace reference to deprecated exception class

### DIFF
--- a/CRM/Anonymiser/Configuration.php
+++ b/CRM/Anonymiser/Configuration.php
@@ -518,7 +518,7 @@ class CRM_Anonymiser_Configuration {
    * @param $entity
    *
    * @return mixed
-   * @throws \CiviCRM_API3_Exception
+   * @throws \CRM_Core_Exception
    */
   public function getCustomTablesForEntity($entity) {
     if (!isset(\Civi::$statics[E::LONG_NAME]['custom_tables'][$entity]) && !is_array(\Civi::$statics[E::LONG_NAME]['custom_tables'][$entity])) {

--- a/CRM/Anonymiser/Worker.php
+++ b/CRM/Anonymiser/Worker.php
@@ -427,7 +427,7 @@ class CRM_Anonymiser_Worker {
    * @param $clearedEntities
    *
    * @return void
-   * @throws \CiviCRM_API3_Exception
+   * @throws \CRM_Core_Exception
    */
   protected function clearCustomData($clearedEntities) {
     $sqlStatements = [];

--- a/Civi/Anonymiser/ActionProvider/Actions/AnonymiseAction.php
+++ b/Civi/Anonymiser/ActionProvider/Actions/AnonymiseAction.php
@@ -40,7 +40,7 @@ class AnonymiseAction extends AbstractAction {
     $contact_id = $parameters->getParameter('contact_id');
     try {
       civicrm_api3('Contact', 'anonymise', ['contact_id' => $contact_id]);
-    } catch (\CiviCRM_API3_Exception $ex) {
+    } catch (\CRM_Core_Exception $ex) {
       // Do nothing.
     }
   }


### PR DESCRIPTION
The api-specific exception classes have been deprecated and will soon be removed from core.
They are identical to CRM_Core_Exception.